### PR TITLE
fixed: target name for ninja backend

### DIFF
--- a/mcw/ninja.py
+++ b/mcw/ninja.py
@@ -44,6 +44,9 @@ class NinjaBackend:
     def get_target(self, target_name):
         target = next((t for t in self.meson.get_targets() if t['name'] == target_name), None)
         if target:
-            return self.meson.get_target_filename(target)
+            target_filename = self.meson.get_target_filename(target)
+            base_dirname = os.path.basename(os.path.dirname(target_filename))
+            base_filename = os.path.basename(target_filename)
+            return os.path.join(base_dirname, base_filename)
 
         return target_name


### PR DESCRIPTION
First of all, good job on fixing the issue with the target filename. This is the only fork that actually loaded for me in CLion :slightly_smiling_face: 

However I wasn't able to build any generated targets, and I noticed that the target name passed to ninja (as specified in `ninja.py`) did not match what was generated in `build.ninja`.

This change fixes the issue for me, though it feels hacky and I'm not sure whether or not it breaks other users' workflows?